### PR TITLE
fix file editing: add "file" and "coreutils" deps

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -26,13 +26,17 @@
             "cockpit",
             "python3",
             "rsync",
-            "zip"
+            "zip",
+            "file",
+            "coreutils"
         ],
         "el": [
             "cockpit",
             "python3",
             "rsync",
-            "zip"
+            "zip",
+            "file",
+            "coreutils"
         ]
     },
     "releases": [


### PR DESCRIPTION
installing the cockpit-navigator package on a minimal system does not install "file" 
when trying to open a text file for editing an uncought promise is being caused here:

https://github.com/45Drives/cockpit-navigator/blob/a285fde2e016203e4214eec1804cd5296916bd58/navigator/components/NavFile.js#L92

a quick search for cockpit.spawn shows that "mkdir", "rmdir" ... are spawned as well which are provided by "coreutils".