### PR TITLE
0.5.10 fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
-## Cockpit Navigator 0.5.9-1
+## Cockpit Navigator 0.5.10-1
 
-* Fix CSS for Cockpit 273 and greater
+* Disallow changing selected file/folder while editing permissions
+* Allow opening non-text file for editing via prompt

--- a/README.md
+++ b/README.md
@@ -23,17 +23,17 @@ With no command line use needed, you can:
 # Installation
 ## From Github Release
 ### Ubuntu
-1. `$ wget https://github.com/45Drives/cockpit-navigator/releases/download/v0.5.8/cockpit-navigator_0.5.8-1focal_all.deb`
-1. `# apt install ./cockpit-navigator_0.5.8-1focal_all.deb`
+1. `$ wget https://github.com/45Drives/cockpit-navigator/releases/download/v0.5.10/cockpit-navigator_0.5.10-1focal_all.deb`
+1. `# apt install ./cockpit-navigator_0.5.10-1focal_all.deb`
 ### EL7
-1. `# yum install https://github.com/45Drives/cockpit-navigator/releases/download/v0.5.8/cockpit-navigator-0.5.8-1.el7.noarch.rpm`
+1. `# yum install https://github.com/45Drives/cockpit-navigator/releases/download/v0.5.10/cockpit-navigator-0.5.10-1.el7.noarch.rpm`
 ### EL8
-1. `# dnf install https://github.com/45Drives/cockpit-navigator/releases/download/v0.5.8/cockpit-navigator-0.5.8-1.el8.noarch.rpm`
+1. `# dnf install https://github.com/45Drives/cockpit-navigator/releases/download/v0.5.10/cockpit-navigator-0.5.10-1.el8.noarch.rpm`
 ## From Source
 1. Ensure dependencies are installed: `cockpit`, `python3`, `rsync`, `zip`.
 1. `$ git clone https://github.com/45Drives/cockpit-navigator.git`
 1. `$ cd cockpit-navigator`
-1. `$ git checkout <version>` (v0.5.8 is latest)
+1. `$ git checkout <version>` (v0.5.10 is latest)
 1. `# make install`
 ## From 45Drives Repositories
 ### Automatic Repo Setup with Script

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
     "name": "cockpit-navigator",
     "title": "Cockpit Navigator",
     "prerelease": false,
-    "version": "0.5.9",
+    "version": "0.5.10",
     "buildVersion": "1",
     "author": "Josh Boudreau <jboudreau@45drives.com>",
     "url": "https://github.com/45Drives/cockpit-navigator",
@@ -59,7 +59,7 @@
     ],
     "changelog": {
         "urgency": "medium",
-        "version": "0.5.9",
+        "version": "0.5.10",
         "buildVersion": "1",
         "ignore": [],
         "date": null,

--- a/navigator/components/NavWindow.js
+++ b/navigator/components/NavWindow.js
@@ -210,6 +210,8 @@ export class NavWindow {
 	}
 	
 	clear_selected() {
+		if (this.editing_permissions)
+			return;
 		for (let entry of this.selected_entries) {
 			entry.unstyle_selected();
 		}
@@ -221,11 +223,15 @@ export class NavWindow {
 	 * @param {NavEntry} entry 
 	 */
 	select_one(entry) {
+		if (this.editing_permissions)
+			return;
 		entry.style_selected();
 		this.selected_entries.add(entry);
 	}
 
 	deselect_one(entry) {
+		if (this.editing_permissions)
+			return;
 		entry.unstyle_selected();
 		this.selected_entries.delete(entry);
 	}
@@ -236,6 +242,8 @@ export class NavWindow {
 	 * @param {NavEntry} end 
 	 */
 	select_range(start, end) {
+		if (this.editing_permissions)
+			return;
 		let start_ind = this.entries.indexOf(start);
 		let end_ind = this.entries.indexOf(end);
 		if (start_ind === -1 || end_ind === -1)
@@ -252,6 +260,8 @@ export class NavWindow {
 	}
 
 	reset_selection() {
+		if (this.editing_permissions)
+			return;
 		this.clear_selected();
 		this.select_one(this.pwd());
 		this.last_selected_entry = null;
@@ -268,6 +278,8 @@ export class NavWindow {
 	 * @param {Boolean} ctrl 
 	 */
 	set_selected(target, shift, ctrl) {
+		if (this.editing_permissions)
+			return;
 		if (!ctrl && !shift)
 			this.clear_selected();
 		if (!shift || !this.last_selected_entry)
@@ -299,6 +311,8 @@ export class NavWindow {
 	}
 
 	select_all() {
+		if (this.editing_permissions)
+			return;
 		this.clear_selected();
 		this.select_range(this.entries[0], this.entries[this.entries.length - 1]);
 		this.update_selection_info();
@@ -395,11 +409,13 @@ export class NavWindow {
 		document.getElementById("nav-mode-preview").innerText = "unchanged";
 		document.getElementById("nav-edit-properties").style.display = "flex";
 		document.getElementById("nav-show-properties").style.display = "none";
+		this.editing_permissions = true;
 	}
 	
 	hide_edit_selected() {
 		document.getElementById("nav-show-properties").style.display = "flex";
 		document.getElementById("nav-edit-properties").style.display = "none";
+		this.editing_permissions = false;
 	}
 	
 	/**

--- a/packaging/el7/main.spec
+++ b/packaging/el7/main.spec
@@ -32,6 +32,9 @@ rm -rf %{buildroot}
 /usr/share/cockpit/navigator/*
 
 %changelog
+* Wed Oct 26 2022 Joshua Boudreau <jboudreau@45drives.com> 0.5.10-1
+- Disallow changing selected file/folder while editing permissions
+- Allow opening non-text file for editing via prompt
 * Fri Aug 05 2022 Joshua Boudreau <jboudreau@45drives.com> 0.5.9-1
 - Fix CSS for Cockpit 273 and greater
 * Mon Jun 06 2022 Joshua Boudreau <jboudreau@45drives.com> 0.5.8-2

--- a/packaging/el8/main.spec
+++ b/packaging/el8/main.spec
@@ -32,6 +32,9 @@ rm -rf %{buildroot}
 /usr/share/cockpit/navigator/*
 
 %changelog
+* Wed Oct 26 2022 Joshua Boudreau <jboudreau@45drives.com> 0.5.10-1
+- Disallow changing selected file/folder while editing permissions
+- Allow opening non-text file for editing via prompt
 * Fri Aug 05 2022 Joshua Boudreau <jboudreau@45drives.com> 0.5.9-1
 - Fix CSS for Cockpit 273 and greater
 * Mon Jun 06 2022 Joshua Boudreau <jboudreau@45drives.com> 0.5.8-2

--- a/packaging/focal/changelog
+++ b/packaging/focal/changelog
@@ -1,3 +1,10 @@
+cockpit-navigator (0.5.10-1focal) focal; urgency=medium
+
+  * Disallow changing selected file/folder while editing permissions
+  * Allow opening non-text file for editing via prompt
+
+ -- Joshua Boudreau <jboudreau@45drives.com>  Wed, 26 Oct 2022 14:40:50 -0300
+
 cockpit-navigator (0.5.9-1focal) focal; urgency=medium
 
   * Fix CSS for Cockpit 273 and greater


### PR DESCRIPTION
- Disallow changing selected file/folder while editing permissions
- Allow opening file for editing even if it isn't detected as plain text via a user prompt

Closes #45
Closes #50